### PR TITLE
Fix default locale in view page

### DIFF
--- a/src/Resources/Pages/ViewRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/ViewRecord/Concerns/Translatable.php
@@ -27,6 +27,8 @@ trait Translatable
             is_subclass_of(static::class, ViewRecord::class),
             new RuntimeException('dont use the trait "' . Translatable::class . '" with "' . static::class . '"')
         );
+
+        $this->activeLocale = static::getResource()::getDefaultTranslatableLocale();
     }
 
     public function updatingActiveLocale(): void


### PR DESCRIPTION
When there is no `en` locale provided by `SomeResource::getTranslatableLocales()` and `SomeResource::getDefaultTranslatableLocale()` points to another language than `en`, the view page doesn't display the correct value.

---

- `filament/filament`: `4.0.18`
- `lara-zeus/spatie-translatable`: `1.0.1`