### PR TITLE
feature: session-based locale persistence

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -26,6 +26,22 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+## Persist active local in Session
+
+to remember the user's selected locale throughout their session, you can pass the method `persist()`
+
+```php
+use LaraZeus\SpatieTranslatable\SpatieTranslatablePlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->plugin(SpatieTranslatablePlugin::make())
+        ->persist();
+}
+```
+
 ## Setting the default translatable locales
 
 To set up the locales that can be used to translate content, you can pass an array of locales to the `defaultLocales()` plugin method:

--- a/src/Resources/Concerns/HasActiveLocaleSwitcher.php
+++ b/src/Resources/Concerns/HasActiveLocaleSwitcher.php
@@ -35,8 +35,11 @@ trait HasActiveLocaleSwitcher
         return SpatieTranslatableContentDriver::class;
     }
 
-    public function updatedActiveLocale(string $newActiveLocale): void
+    public function updatedActiveLocale(): void
     {
+        // Store the selected locale in session for persistence across page loads
+        session()->put('spatie_translatable_active_locale', $this->activeLocale);
+
         if (blank($this->oldActiveLocale)) {
             return;
         }
@@ -65,5 +68,16 @@ trait HasActiveLocaleSwitcher
 
             throw $e;
         }
+    }
+
+    protected function getStoredActiveLocale(): ?string
+    {
+        $locale = session()->get('spatie_translatable_active_locale');
+
+        if ($locale && in_array($locale, $this->getTranslatableLocales(), true)) {
+            return $locale;
+        }
+
+        return null;
     }
 }

--- a/src/Resources/Concerns/HasActiveLocaleSwitcher.php
+++ b/src/Resources/Concerns/HasActiveLocaleSwitcher.php
@@ -37,8 +37,9 @@ trait HasActiveLocaleSwitcher
 
     public function updatedActiveLocale(): void
     {
-        // Store the selected locale in session for persistence across page loads
-        session()->put('spatie_translatable_active_locale', $this->activeLocale);
+        if (filament('spatie-translatable')->getPersistLocale()) {
+            session()->put('spatie_translatable_active_locale', $this->activeLocale);
+        }
 
         if (blank($this->oldActiveLocale)) {
             return;
@@ -72,6 +73,10 @@ trait HasActiveLocaleSwitcher
 
     protected function getStoredActiveLocale(): ?string
     {
+        if (! filament('spatie-translatable')->getPersistLocale()) {
+            return null;
+        }
+
         $locale = session()->get('spatie_translatable_active_locale');
 
         if ($locale && in_array($locale, $this->getTranslatableLocales(), true)) {

--- a/src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
+++ b/src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
@@ -11,7 +11,8 @@ trait HasTranslatableFormWithExistingRecordData
 
     protected function fillForm(): void
     {
-        $this->activeLocale ??= $this->getDefaultTranslatableLocale();
+        // check for session first, then fall back to default locale
+        $this->activeLocale ??= $this->getStoredActiveLocale() ?? $this->getDefaultTranslatableLocale();
 
         $record = $this->getRecord();
         $translatableAttributes = static::getResource()::getTranslatableAttributes();

--- a/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/CreateRecord/Concerns/Translatable.php
@@ -33,7 +33,7 @@ trait Translatable
 
     public function mountTranslatable(): void
     {
-        $this->activeLocale = static::getResource()::getDefaultTranslatableLocale();
+        $this->activeLocale = $this->getStoredActiveLocale() ?? static::getResource()::getDefaultTranslatableLocale();
     }
 
     public function getTranslatableLocales(): array

--- a/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -31,6 +31,11 @@ trait Translatable
         );
     }
 
+    public function mountTranslatable(): void
+    {
+        $this->activeLocale = $this->getStoredActiveLocale() ?? static::getResource()::getDefaultTranslatableLocale();
+    }
+
     public function getTranslatableLocales(): array
     {
         return static::getResource()::getTranslatableLocales();

--- a/src/Resources/Pages/ListRecords/Concerns/Translatable.php
+++ b/src/Resources/Pages/ListRecords/Concerns/Translatable.php
@@ -24,7 +24,7 @@ trait Translatable
 
     public function mountTranslatable(): void
     {
-        $this->activeLocale = static::getResource()::getDefaultTranslatableLocale();
+        $this->activeLocale = $this->getStoredActiveLocale() ?? static::getResource()::getDefaultTranslatableLocale();
     }
 
     public function getTranslatableLocales(): array

--- a/src/Resources/Pages/ViewRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/ViewRecord/Concerns/Translatable.php
@@ -26,7 +26,7 @@ trait Translatable
             new RuntimeException('dont use the trait "' . Translatable::class . '" with "' . static::class . '"')
         );
 
-        $this->activeLocale = static::getResource()::getDefaultTranslatableLocale();
+        $this->activeLocale = $this->getStoredActiveLocale() ?? static::getResource()::getDefaultTranslatableLocale();
     }
 
     public function updatingActiveLocale(): void
@@ -34,8 +34,10 @@ trait Translatable
         $this->oldActiveLocale = $this->activeLocale;
     }
 
-    public function updatedActiveLocale(string $newActiveLocale): void
+    public function updatedActiveLocale(): void
     {
+        session()->put('spatie_translatable_active_locale', $this->activeLocale);
+
         if (blank($this->oldActiveLocale)) {
             return;
         }

--- a/src/Resources/Pages/ViewRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/ViewRecord/Concerns/Translatable.php
@@ -26,7 +26,8 @@ trait Translatable
             new RuntimeException('dont use the trait "' . Translatable::class . '" with "' . static::class . '"')
         );
 
-        $this->activeLocale = $this->getStoredActiveLocale() ?? static::getResource()::getDefaultTranslatableLocale();
+        $this->activeLocale = $this->getStoredActiveLocale()
+            ?? static::getResource()::getDefaultTranslatableLocale();
     }
 
     public function updatingActiveLocale(): void
@@ -36,7 +37,9 @@ trait Translatable
 
     public function updatedActiveLocale(): void
     {
-        session()->put('spatie_translatable_active_locale', $this->activeLocale);
+        if (filament('spatie-translatable')->getPersistLocale()) {
+            session()->put('spatie_translatable_active_locale', $this->activeLocale);
+        }
 
         if (blank($this->oldActiveLocale)) {
             return;

--- a/src/SpatieTranslatableContentDriver.php
+++ b/src/SpatieTranslatableContentDriver.php
@@ -13,10 +13,7 @@ use function Filament\Support\generate_search_term_expression;
 
 class SpatieTranslatableContentDriver implements TranslatableContentDriver
 {
-    public function __construct(protected string $activeLocale)
-    {
-        //
-    }
+    public function __construct(protected string $activeLocale) {}
 
     public function isAttributeTranslatable(string $model, string $attribute): bool
     {

--- a/src/SpatieTranslatablePlugin.php
+++ b/src/SpatieTranslatablePlugin.php
@@ -12,6 +12,8 @@ class SpatieTranslatablePlugin implements Plugin
 
     protected bool $useFallbackLocale = false;
 
+    protected bool $persistLocale = false;
+
     protected ?Closure $getLocaleLabelUsing = null;
 
     final public function __construct()
@@ -63,6 +65,18 @@ class SpatieTranslatablePlugin implements Plugin
         return $this;
     }
 
+    public function getPersistLocale(): bool
+    {
+        return $this->persistLocale;
+    }
+
+    public function persist(bool $persistLocale = true): static
+    {
+        $this->persistLocale = $persistLocale;
+
+        return $this;
+    }
+
     public function getLocaleLabelUsing(?Closure $callback): static
     {
         $this->getLocaleLabelUsing = $callback;
@@ -72,7 +86,7 @@ class SpatieTranslatablePlugin implements Plugin
 
     public function getLocaleLabel(string $locale, ?string $displayLocale = null): ?string
     {
-        $displayLocale ??= app()->getLocale();
+        $displayLocale ??= session('spatie_translatable_active_locale') ?? app()->getLocale();
 
         $label = null;
 


### PR DESCRIPTION
### Feature: Session-Based Locale Persistence
## Problem:
The locale switcher selection was not persisted across page refreshes or navigation, forcing users to re-select their preferred locale on every page load.
This creates a pretty horrible UX when the user selects a locale, navigates away and it fallbacks to the default locale. Imagine working for hundreds of entries and you're forced to select the locale on every single page redirect.
## Solution:
Implemented session-based storage to remember the user's selected locale throughout their session.

### Changes
## Changes Made:
1. Core Session Management
File: src/Resources/Concerns/HasActiveLocaleSwitcher.php
Added session storage in updatedActiveLocale() method to persist locale selection
Added getStoredActiveLocale() helper method to retrieve and validate stored locale from session
2. Form Data Population Fix
File: src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
Updated fillForm() to check session before setting default locale
Fixes timing issue where form data was populated before mount lifecycle checked session
3. Page-Specific Mount Methods
Updated all page types to check session on initialization:
src/Resources/Pages/ListRecords/Concerns/Translatable.php - Updated mountTranslatable()
src/Resources/Pages/CreateRecord/Concerns/Translatable.php - Updated mountTranslatable()
src/Resources/Pages/EditRecord/Concerns/Translatable.php - Added mountTranslatable() method
src/Resources/Pages/ViewRecord/Concerns/Translatable.php - Updated bootTranslatable() and updatedActiveLocale()
4. Code Style
File: src/SpatieTranslatableContentDriver.php
Pint auto-formatting of from pint constructor
5. Removed unused variables
File: src/Resources/Concerns/HasActiveLocaleSwitcher.php
string $newActiveLocale param was not used anywhere
src/Resources/Pages/ViewRecord/Concerns/Translatable.php
string $newActiveLocale param was not used anywhere