### PR TITLE
Fix incorrect example in documentation

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -37,8 +37,10 @@ public function panel(Panel $panel): Panel
 {
     return $panel
         // ...
-        ->plugin(SpatieTranslatablePlugin::make())
-        ->persist();
+        ->plugin(
+            SpatieTranslatablePlugin::make()
+                ->persist(),
+        );
 }
 ```
 


### PR DESCRIPTION
The current documentation shows the persist() method being called directly on the Panel instance, which causes an error:

`Method Filament\Panel::persist does not exist.`

However, persist() is a method of the SpatieTranslatablePlugin class, not of Filament\Panel.
This PR updates the example to call persist() correctly on the plugin instance.

Before : 

```php
$panel
    ->plugin(SpatieTranslatablePlugin::make())
    ->persist();
```

After : 

```php
$panel
    ->plugin(
        SpatieTranslatablePlugin::make()
            ->persist()
    );
```

The example now works as expected without throwing an error.