### PR TITLE
Fix bug with saving relations after switching locale

### DIFF
--- a/src/Resources/Concerns/HasActiveLocaleSwitcher.php
+++ b/src/Resources/Concerns/HasActiveLocaleSwitcher.php
@@ -51,13 +51,13 @@ trait HasActiveLocaleSwitcher
 
         try {
             $this->otherLocaleData[$this->oldActiveLocale] = Arr::only(
-                $this->form->getState(),
+                $this->form->getRawState(),
                 $translatableAttributes
             );
 
             $this->form->fill([
                 ...Arr::except(
-                    $this->form->getState(),
+                    $this->form->getRawState(),
                     $translatableAttributes
                 ),
                 ...$this->otherLocaleData[$this->activeLocale] ?? [],


### PR DESCRIPTION
Previously the component used getState() during the locale-switch process.
This triggered the following logic:

```
$afterValidate || $this->saveRelationships();
$afterValidate || $this->loadStateFromRelationships(shouldHydrate: true);
```

Because of this, relationship data was being saved too early —
specifically, it was saved into the newly selected locale before the actual locale switch happened.

As a result, the model ended up storing incorrect data whenever the user switched locales.