### PR TITLE
feat: add getOldActiveLocale() accessor to HasActiveLocaleSwitcher

### DIFF
--- a/src/Resources/Concerns/HasActiveLocaleSwitcher.php
+++ b/src/Resources/Concerns/HasActiveLocaleSwitcher.php
@@ -27,6 +27,11 @@ trait HasActiveLocaleSwitcher
         return $this->activeLocale;
     }
 
+    public function getOldActiveLocale(): ?string
+    {
+        return $this->oldActiveLocale;
+    }
+
     /**
      * @return class-string<TranslatableContentDriver> | null
      */


### PR DESCRIPTION
## Feature Request: Add `getOldActiveLocale()` to `HasActiveLocaleSwitcher`

### Problem

When building Filament resources with `LocaleSwitcher`, `HasActiveLocaleSwitcher` exposes `activeLocale` but has no public accessor for the previous locale. The `$oldActiveLocale` property is already populated by `updatingActiveLocale()` in `EditRecord\Concerns\Translatable`, but it's not accessible from outside the trait.

This makes it impossible to implement locale-aware validation rules at the field level. When the user switches locale, the field still holds the value from the previous locale — so a rule injecting `$livewire` needs to know which locale was active before the switch to validate correctly.

### Proposed fix

Add to `HasActiveLocaleSwitcher`:
```php
public function getOldActiveLocale(): ?string
{
    return $this->oldActiveLocale;
}
```

With this accessor, locale-aware validation rules can be declared cleanly at the Filament field level:

```php
$oldLocale = $livewire->getOldActiveLocale();
$currentLocale = $livewire->activeLocale;

$localeToCheck = ($oldLocale && $oldLocale !== $currentLocale) ? $oldLocale : $currentLocale;

$exists = $this->model::query()
    ->where("{$this->column}->{$localeToCheck}", $value)
    ->when($this->ignoreId, fn($q) => $q->where('id', '!=', $this->ignoreId))
    ->exists();
```

This is a non-breaking, single-method addition. Closes #47 .