### PR TITLE
Avoid triggering form validation when switching active locale

### DIFF
--- a/src/Resources/Concerns/HasActiveLocaleSwitcher.php
+++ b/src/Resources/Concerns/HasActiveLocaleSwitcher.php
@@ -51,13 +51,13 @@ trait HasActiveLocaleSwitcher
 
         try {
             $this->otherLocaleData[$this->oldActiveLocale] = Arr::only(
-                $this->form->getState(),
+                $this->form->getRawState(),
                 $translatableAttributes
             );
 
             $this->form->fill([
                 ...Arr::except(
-                    $this->form->getState(),
+                    $this->form->getRawState(),
                     $translatableAttributes
                 ),
                 ...$this->otherLocaleData[$this->activeLocale] ?? [],


### PR DESCRIPTION
### 🐛 Problem

Switching the active locale using the locale switcher triggers form validation

As a result, validation errors may appear when simply switching locales, even when not editing the default locale.
When working in a non-default locale, all fields do not necessarily need to be filled, as they can fall back to the default locale. Triggering validation in this context disrupts that expected behavior.

### ✅ Solution

Replaced calls to:

```php
$this->form->getState()
```
With
```php
$this->form->getRawState()
```